### PR TITLE
fix: Fix Makefile for default make shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ $(SERVICE_NAME): .state
 COMMIT := $(shell git rev-parse HEAD)
 rev = $(shell git rev-parse --abbrev-ref HEAD)
 BRANCH := $(shell \
-if [[ "${rev}" != "HEAD" ]]; then \
+if [ "${rev}" != "HEAD" ]; then \
 	echo "${rev}" ; \
 elif [ -n "${BRANCH_NAME}" ]; then \
 	echo "${BRANCH_NAME}"; \


### PR DESCRIPTION
Заметил при сборке следующую (почему-то скипаемую) ошибку:
https://github.com/rbkmoney/image-build-erlang/pull/28/checks?check_run_id=2620016836#step:6:9
```
 /bin/sh: 1: [[: not found
 ```
 
 Makes sense:
 > [The program used as the shell is taken from the variable SHELL. If this variable is not set in your makefile, the program /bin/sh is used as the shell.](https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html)