### PR TITLE
erlang: downgrade to 23.3.4.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:23.2.7
+FROM erlang:23.3.4
 
 ENV LANG=C.UTF-8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:23.3.4
+FROM erlang:23.3.4.3
 
 ENV LANG=C.UTF-8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:24.0.2
+FROM erlang:23.2.7
 
 ENV LANG=C.UTF-8
 


### PR DESCRIPTION
понижение версии erlang  в связи с неготовностью базовой инфраструктуры сервисов (jose, lechiffre)